### PR TITLE
Update `piplite_urls` configuration

### DIFF
--- a/jupyter_lite_config.json
+++ b/jupyter_lite_config.json
@@ -4,9 +4,11 @@
             "https://github.com/conda-forge/releases/releases/download/noarch/ipyflex-0.2.2-pyhd8ed1ab_0.tar.bz2/ipyflex-0.2.2-pyhd8ed1ab_0.tar.bz2",
             "https://github.com/conda-forge/releases/releases/download/noarch/jupyterlab_widgets-1.0.2-pyhd8ed1ab_0.tar.bz2/jupyterlab_widgets-1.0.2-pyhd8ed1ab_0.tar.bz2"
         ],
+        "ignore_sys_prefix": true
+    },
+    "PipliteAddon": {
         "piplite_urls": [
             "https://files.pythonhosted.org/packages/7b/bb/0ec098dd6c4164283618dfaf609731d32b2354f2d18b970e474d864fe90c/ipyflex-0.2.2-py2.py3-none-any.whl"
-        ],
-      "ignore_sys_prefix": true
+        ]
     }
 }


### PR DESCRIPTION
With JupyterLite `0.1.0b17`, the `piplite_urls` configuration has changed and should now be put under the `PipliteAddon` field: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b17